### PR TITLE
Specifying supported images of type gif, png, jpeg, progressive jpeg, tiff, bmp, and webp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vendor/**/CONTRIBUTORS
 vendor/**/Makefile
 vendor/**/*_ZH.md
 vendor/**/*.sh
+
+.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ADD . /go/src/willnorris.com/go/imageproxy
 RUN go get willnorris.com/go/imageproxy/cmd/imageproxy
 
 CMD []
-ENTRYPOINT /go/bin/imageproxy -addr 0.0.0.0:80 -contentTypes=image/png,image/jpg,image/gif,image/webp,image/jpeg,image/pjpeg
+ENTRYPOINT /go/bin/imageproxy -addr 0.0.0.0:80 -contentTypes=image/png,image/jpg,image/gif,image/webp,image/jpeg,image/pjpeg,image/tiff,image/bmp
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ ADD . /go/src/willnorris.com/go/imageproxy
 RUN go get willnorris.com/go/imageproxy/cmd/imageproxy
 
 CMD []
-ENTRYPOINT /go/bin/imageproxy -addr 0.0.0.0:80
+ENTRYPOINT /go/bin/imageproxy -addr 0.0.0.0:80 -contentTypes=image/png,image/jpg,image/gif,image/webp,image/jpeg,image/pjpeg
 
 EXPOSE 80


### PR DESCRIPTION
This fixes the issue raised here: https://buffer.atlassian.net/browse/PUB-1862

Specifying supported images of type gif, png, jpeg, progressive jpeg, tiff, bmp, and webp to just those supported by third party providers.

This will allow us to deal with images safely, but not have to deal with unsupported types.

CC/ @albennett, @anafilipadealmeida, @chayjay, @MayaUribe, @hamstu, @josem, @diannemcewan  for informational purposes