### PR TITLE
Upgrading safeimage chart to 1.1.1

### DIFF
--- a/helm/safeimage.yaml
+++ b/helm/safeimage.yaml
@@ -2,7 +2,7 @@ name: safeimage
 namespace: buffer
 deploymentUrl: "safeimage.buffer.com"
 chart: "buffercharts/buffer-service"
-chartVersion: "1.0.2"
+chartVersion: "1.1.1"
 cdEnabled: true
 cdBranchEnabled: true
 dockerfile: Dockerfile


### PR DESCRIPTION
Upgraded the chart `buffer-service` used by `safeimage` from version 1.0.2 to 1.1.1